### PR TITLE
Symbolic Link for juju if accessed from /usr/local/bin

### DIFF
--- a/bin/juju
+++ b/bin/juju
@@ -21,8 +21,15 @@
 NAME='juju'
 VERSION='0.5.8'
 
-HOME_DIR="$( cd ../"$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source "$(HOME_DIR)/lib/juju/core.sh"
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+HOME_DIR="$(dirname $( cd -P "$( dirname "$SOURCE" )" && pwd ))"
+
+source "$HOME_DIR/lib/juju/core.sh"
 
 ###################################
 ### General functions           ###

--- a/bin/juju
+++ b/bin/juju
@@ -21,7 +21,8 @@
 NAME='juju'
 VERSION='0.5.8'
 
-source "$(dirname $0)/../lib/juju/core.sh"
+HOME_DIR="$( cd ../"$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "$(HOME_DIR)/lib/juju/core.sh"
 
 ###################################
 ### General functions           ###


### PR DESCRIPTION
juju.sh unable to resolve symbolic link for /usr/local/bin/juju

updated the directory path.
